### PR TITLE
draggable item didn't move on Google chrome

### DIFF
--- a/src/directives/draggable.js
+++ b/src/directives/draggable.js
@@ -66,11 +66,11 @@ dragdropModule.directive('draggable', [
           $element.css('position', 'relative');
         }
         
-        if (top === '') {
+        if (top === ''  || top === 'auto') {
           $element.css('top', '0px');
         }
         
-        if (left === '') {
+        if (left === '' || left === 'auto') {
           $element.css('left', '0px');
         }
       })();


### PR DESCRIPTION
On the latest Google Chrome browser, top and left  were set to auto on draggable item. Without these changes, the item was not moving (css not getting updated) on chrome. It was working fine on firefox without this fix
